### PR TITLE
clonable cell parser

### DIFF
--- a/ton_core/src/cell/cell_parser.rs
+++ b/ton_core/src/cell/cell_parser.rs
@@ -6,7 +6,7 @@ use crate::errors::TonCoreError;
 use bitstream_io::{BigEndian, BitRead, BitReader};
 use std::io::{Cursor, SeekFrom};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CellParser<'a> {
     cell: &'a TonCell,
     data_reader: CellBitsReader<'a>,


### PR DESCRIPTION
The ability to clone `CellParser` could be useful in some cases.