### PR TITLE
expose cell type in builder and parser

### DIFF
--- a/ton_core/src/cell/cell_builder.rs
+++ b/ton_core/src/cell/cell_builder.rs
@@ -147,9 +147,7 @@ impl CellBuilder {
 
     pub fn data_bits_left(&self) -> usize { TonCell::MAX_DATA_LEN_BITS - self.data_len_bits }
 
-    pub fn set_type(&mut self, cell_type: CellType) {
-        self.cell_type = cell_type;
-    }
+    pub fn set_type(&mut self, cell_type: CellType) { self.cell_type = cell_type; }
 
     fn ensure_capacity(&mut self, bits_len: usize) -> Result<(), TonCoreError> {
         let new_bits_len = self.data_len_bits + bits_len;

--- a/ton_core/src/cell/cell_parser.rs
+++ b/ton_core/src/cell/cell_parser.rs
@@ -130,9 +130,7 @@ impl<'a> CellParser<'a> {
         bail_ton_core_data!("Cell is not empty: {bits_left} bits left, {refs_left} refs left");
     }
 
-    pub fn cell_type(&self) -> CellType {
-        self.cell.cell_type
-    }
+    pub fn cell_type(&self) -> CellType { self.cell.cell_type }
 
     // returns remaining bits
     fn ensure_enough_bits(&mut self, bit_len: usize) -> Result<usize, TonCoreError> {


### PR DESCRIPTION
I haven't found a way to conveniently access or edit cell type when working with builders and parsers.
So I think cell type should be exposed on them too.