### PR TITLE
PartialEq for TVMStack

### DIFF
--- a/ton/src/block_tlb/tvm_types/tvm_stack.rs
+++ b/ton/src/block_tlb/tvm_types/tvm_stack.rs
@@ -20,7 +20,7 @@ macro_rules! extract_stack_val {
 
 // https://github.com/ton-blockchain/ton/blob/ed4682066978f69ffa38dd98912ca77d4f660f66/crypto/block/block.tlb#L864
 // Doesn't implement tlb schema directly for convenience purposes
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct TVMStack(Vec<TVMStackValue>);
 
 impl Deref for TVMStack {

--- a/ton/src/block_tlb/tvm_types/tvm_stack_value.rs
+++ b/ton/src/block_tlb/tvm_types/tvm_stack_value.rs
@@ -12,7 +12,7 @@ use ton_core::TLB;
 use ton_core::cell::TonCell;
 use ton_core::types::tlb_core::TLBRef;
 
-#[derive(Clone, TLB)]
+#[derive(Clone, TLB, PartialEq)]
 pub enum TVMStackValue {
     Null(TVMNull),
     TinyInt(TVMTinyInt),
@@ -25,41 +25,41 @@ pub enum TVMStackValue {
     Tuple(TVMTuple),
 }
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 #[tlb(prefix = 0x00, bits_len = 8)]
 pub struct TVMNull;
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 #[tlb(prefix = 0x01, bits_len = 8)]
 pub struct TVMTinyInt {
     pub value: i64,
 }
 
 // vm_stk_int#0201_ value:int257 = VmStackValue; means 0x0201 without latest bit ==> 0000001000000000
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 #[tlb(prefix = 0x0100, bits_len = 15)]
 pub struct TVMInt {
     #[tlb(bits_len = 257)]
     pub value: BigInt,
 }
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 #[tlb(prefix = 0x02ff, bits_len = 16)]
 pub struct TVMNan;
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 #[tlb(prefix = 0x03, bits_len = 8)]
 pub struct TVMCell {
     pub value: TLBRef<TonCell>,
 }
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 #[tlb(prefix = 0x05, bits_len = 8)]
 pub struct TVMBuilder {
     pub cell: TLBRef<TonCell>,
 }
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 pub enum TVMCont {
     Std(VMContStd),
     Envelope(TVMContEnvelope),
@@ -73,7 +73,7 @@ pub enum TVMCont {
     PushInt(VMContPushInt),
 }
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 pub struct VMControlData {
     #[tlb(bits_len = 13)]
     pub nargs: Option<u16>,
@@ -82,37 +82,37 @@ pub struct VMControlData {
     pub cp: Option<i16>,
 }
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 pub struct VMSaveList {
     #[tlb(adapter = "TLBHashMap::<DictKeyAdapterUint<_>, DictValAdapterTLB<_>>::new(4)")]
     pub cregs: HashMap<u8, TVMStackValue>,
 }
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 #[tlb(prefix = 0x00, bits_len = 8)]
 pub struct VMContStd {
     pub data: Arc<VMControlData>,
     pub code: Arc<TVMCellSlice>,
 }
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 #[tlb(prefix = 0x01, bits_len = 8)]
 pub struct TVMContEnvelope {
     pub data: VMControlData,
     pub next: Arc<TLBRef<TVMCont>>,
 }
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 #[tlb(prefix = 0x1000, bits_len = 16)]
 pub struct VMContQuit {
     pub exit_code: i32,
 }
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 #[tlb(prefix = 0x1001, bits_len = 16)]
 pub struct TVMContQuitExc {}
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 #[tlb(prefix = 0x10100, bits_len = 20)]
 pub struct VMContRepeat {
     #[tlb(bits_len = 63)]
@@ -121,20 +121,20 @@ pub struct VMContRepeat {
     pub after: Arc<TLBRef<TVMCont>>,
 }
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 #[tlb(prefix = 0x110000, bits_len = 24)]
 pub struct VMContUntil {
     pub body: Arc<TLBRef<TVMCont>>,
     pub after: Arc<TLBRef<TVMCont>>,
 }
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 #[tlb(prefix = 0x110001, bits_len = 24)]
 pub struct VMContAgain {
     pub body: Arc<TLBRef<TVMCont>>,
 }
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 #[tlb(prefix = 0x110010, bits_len = 24)]
 pub struct VMContWhileCond {
     pub cond: Arc<TLBRef<TVMCont>>,
@@ -142,7 +142,7 @@ pub struct VMContWhileCond {
     pub after: Arc<TLBRef<TVMCont>>,
 }
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 #[tlb(prefix = 0x110011, bits_len = 24)]
 pub struct VMContWhileBody {
     pub cond: Arc<TLBRef<TVMCont>>,
@@ -150,7 +150,7 @@ pub struct VMContWhileBody {
     pub after: Arc<TLBRef<TVMCont>>,
 }
 
-#[derive(Debug, Clone, TLB)]
+#[derive(Debug, Clone, TLB, PartialEq)]
 #[tlb(prefix = 0x1111, bits_len = 16)]
 pub struct VMContPushInt {
     pub value: i32,

--- a/ton/src/block_tlb/tvm_types/tvm_tuple.rs
+++ b/ton/src/block_tlb/tvm_types/tvm_tuple.rs
@@ -19,7 +19,7 @@ macro_rules! extract_tuple_val {
 // https://github.com/ton-blockchain/ton/blob/master/crypto/block/block.tlb#L872C30-L872C40
 // Doesn't implement tlb schema directly for convenience purposes
 // Very similar with VMStackValue, but random access to underlying values
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct TVMTuple(Vec<TVMStackValue>);
 
 impl Deref for TVMTuple {


### PR DESCRIPTION
I would like to have the ability to compare `TVMStack` for unit tests using `assert_eq!` macro.